### PR TITLE
Update package.json to reflect actual license

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dns"
   ],
   "author": "Konstantin Vyatkin <tino@vtkn.io>",
-  "license": "GPL-3.0",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/tinovyatkin/is-localhost-ip/issues"
   },


### PR DESCRIPTION
> Fixes #240 

This fixes a licensing discrepancy that prevents non-GPL projects and their dependencies from using this library.  This would still require a release, as NPM currently lists this as GPL.