### PR TITLE
chore: bump version to 3.0.1

### DIFF
--- a/__tests__/coverage-edge.test.js
+++ b/__tests__/coverage-edge.test.js
@@ -1,0 +1,90 @@
+"use strict";
+
+const { describe, test, mock } = require("node:test");
+const assert = require("node:assert/strict");
+
+mock.module("node:dgram", {
+  namedExports: {
+    /**
+     * Minimal dgram socket mock to exercise canBindToIp edge cases deterministically.
+     * @param {"udp4"|"udp6"} type
+     */
+    createSocket(type) {
+      assert.ok(type === "udp4" || type === "udp6");
+
+      /** @type {Record<string, Function | undefined>} */
+      const listeners = {};
+
+      /** @type {any} */
+      const socket = {
+        once(eventName, listener) {
+          listeners[eventName] = listener;
+          return socket;
+        },
+        unref() {
+          return socket;
+        },
+        bind(port, address) {
+          assert.strictEqual(port, 0);
+          assert.strictEqual(typeof address, "string");
+
+          if (address === "0.0.0.0") {
+            listeners.listening?.();
+            return;
+          }
+
+          if (address === "127.0.0.1") {
+            throw new Error("bind failure");
+          }
+
+          listeners.error?.(new Error("EADDRNOTAVAIL"));
+        },
+        close(callback) {
+          if (callback) callback();
+        },
+      };
+
+      return socket;
+    },
+  },
+});
+
+mock.module("node:dns", {
+  namedExports: {
+    promises: {
+      /**
+       * @param {string} hostname
+       * @param {import("dns").LookupAllOptions} options
+       * @returns {Promise<import("dns").LookupAddress[] | unknown>}
+       */
+      lookup(hostname, options) {
+        assert.ok(options?.all, "options.all should be truthy");
+
+        if (hostname === "test.nonarray") {
+          return Promise.resolve({ address: "127.0.0.1", family: 4 });
+        }
+
+        return Promise.resolve([]);
+      },
+    },
+  },
+});
+
+const isLocalhost = require("../");
+
+describe("coverage edge cases", () => {
+  test("returns false if socket.bind throws synchronously", async () => {
+    assert.strictEqual(await isLocalhost("127.0.0.1", true), false);
+  });
+
+  test("returns true if socket can bind to 0.0.0.0", async () => {
+    assert.strictEqual(await isLocalhost("0.0.0.0"), true);
+  });
+
+  test("throws if dns lookup returns a non-array result", async () => {
+    await assert.rejects(() => isLocalhost("test.nonarray"), {
+      name: "TypeError",
+      message: "DNS Lookup failed.",
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "is-localhost-ip",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "is-localhost-ip",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "22.15.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "is-localhost-ip",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Checks whether given DNS name or IPv4/IPv6 address belongs to a local machine",
   "keywords": [
     "check-localhost",


### PR DESCRIPTION
- Bump package version from 3.0.0 -> 3.0.1
- Add deterministic tests to cover `canBindToIp` error path and the `DNS Lookup failed.` non-array guard
- `npm test` now reports 100% line/branch/function coverage for `index.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive edge-case test coverage for improved reliability and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->